### PR TITLE
Analysis vs Odoo/Manager.io and end-to-end Happy User Journey test

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -112,6 +112,12 @@
 
 _(Epic-sized follow-ups can be tracked here when defined.)_
 
+See `docs/ANALYSIS.md` for the current strengths/weaknesses review vs Odoo and
+Manager.io and the prioritised follow-up list. The end-to-end "Happy User
+Journey" integration test — branch → user → catalog → purchase → goods receipt
+→ transfer → POS shift/cart/payment → sales finalize → trial balance — lives in
+`tests/test_happy_journey.py`.
+
 ---
 
 ## How to update this file

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -1,0 +1,262 @@
+# MEZAN — Backend & Database Analysis
+
+Comparison of the MEZAN ERP backend against two reference systems:
+
+- **Odoo** (Community + Enterprise) — full-stack, model-driven ERP with a deep `account` module, a mature retail/POS stack, and a very large ecosystem of modules (CRM, manufacturing, HR, fleet, etc.).
+- **Manager.io** — desktop/cloud **small-business accounting** product focused on double-entry bookkeeping, VAT, bank reconciliation, and reporting. No POS, no heavy retail.
+
+The goal is to place MEZAN honestly on this spectrum and surface the specific things that are worth fixing or building next.
+
+---
+
+## 1. Executive summary
+
+MEZAN is a **retail-first, API-first backend** built around four strong cores:
+
+1. **Identity & RBAC** — users, fixed base roles, per-user permission overrides, audit logging, onboarding workflow.
+2. **Catalog & inventory** — hierarchical categories, dynamic attributes, purchase orders, OCR‑driven invoice scanning, goods receipts, multi‑branch stock movements, weighted‑average costing.
+3. **POS** — terminals, shifts (open/cash events/Z-style close), carts (park/resume/lock), payments (intent + capture), immutable sales invoices, returns/credit notes.
+4. **Automated GL posting** — POS sales, returns, goods receipts, and approved payslips post idempotent, balanced journal entries; fiscal periods, reversals, AR/AP open‑items subledger, trial balance / GL / P&L / balance sheet reports.
+
+Compared to **Odoo**, MEZAN is a **narrower, tighter surface**: opinionated retail pipeline, clean async SQLAlchemy, idempotency taken seriously, auditable. But the accounting module is **much thinner** — no tax engine, no bank reconciliation, no fixed assets, no budgets, no cash‑flow statement, no manual journals API, no multi‑currency revaluation, and reports are type‑level rollups.
+
+Compared to **Manager.io**, MEZAN has **more operations** (POS, HR, purchasing, branches, RBAC, audit) but **less pure accounting depth** — Manager.io has full VAT/tax codes, bank import & reconciliation, fixed assets, capital accounts, special accounts, inter‑account transfers, billable time/expenses, and a very rich set of statutory reports out of the box.
+
+Net: MEZAN is closer to “**branch‑aware retail operations with a correct but minimal bookkeeping engine**” than to a general‑purpose accounting product.
+
+---
+
+## 2. Strengths
+
+These are areas where the current backend compares **well or better** than Odoo/Manager.io for the intended use case.
+
+### 2.1 Architecture & discipline
+
+- **Clean layering** — `api/v1` (HTTP only), `services/` (logic), `models/` (ORM), `schemas/` (Pydantic). Odoo blurs these across its ORM model layer; Manager.io is a black box. The separation here is easier to test and reason about.
+- **Fully async** — `AsyncSession`, async routes and services. Odoo is still synchronous; Manager.io doesn’t expose a programmable backend.
+- **Idempotency as a first‑class concept** —
+  - `JournalEntry.idempotency_key` unique; `post_journal_entry` no‑ops on duplicates (`app/services/accounting_service.py`).
+  - `StockMovement.idempotency_key` — inventory side is replay‑safe.
+  - POS finalize / capture / receive all take explicit `idempotency_key`.
+  - This is stronger than default Odoo (where retries can duplicate moves unless you add locking).
+- **Alembic‑only migrations** — no `create_all` on boot (`app/main.py` says so explicitly). Production‑appropriate.
+- **Audit logging with `request_id`** — `audit_service.log` + `RequestIDMiddleware`. Hooked into most mutating routes. Manager.io has no audit trail at all.
+- **Double‑entry is enforced in code** — `post_journal_entry` rejects unbalanced batches at cents level. Enforced **always**, not optional.
+
+### 2.2 Retail / POS
+
+- **Shift lifecycle** (`shift_service`) with open float, cash events, closing variance — this is effectively what Odoo POS does, but more explicit at the API level.
+- **Cart state machine** — `draft → active → checkout_locked → paid`, plus park/resume; returns/credit notes with barcode lookup.
+- **Payment provider abstraction** — `in_store`, `mock`, can be extended. Provider selected via `POS_DEFAULT_PAYMENT_PROVIDER`.
+- **Immutable sales invoice + `InvoicePayment` + stock movements in one transaction** (`invoice_service.finalize_paid_cart`). Strong invariant.
+
+### 2.3 Inventory & purchasing
+
+- **Weighted‑average costing per (branch, product)** — `branch_product_costs` table, `apply_receipt_to_weighted_average`. Per‑branch is better than Odoo’s default global costing and aligns with multi‑store retail.
+- **Optical/QR invoice scan pipeline** — `invoice_scan_service` with pluggable OCR providers, manual override path, deterministic parsing, then goods receipt + WAVG + GL posting. This is a real edge over Odoo, where OCR is an Enterprise add‑on that mostly just fills a vendor bill draft.
+- **Branch‑aware stock levels and transfers** — `stock_levels`, `stock_movements`, `transfer_batch` with dispatch/receive.
+
+### 2.4 Accounting basics
+
+- **Branch‑scoped every journal line** — `JournalEntryLine.branch_id` is mandatory. That’s the minimum dimensional accounting needed to run P&L per store, and it’s enforced at the schema level.
+- **Fiscal period lock** — `ensure_period_open` blocks posting to closed months. Period open/close workflow exposed via API. This is often an add‑on in Odoo and absent in many SME tools.
+- **Journal reversal** — `accounting_governance_service.reverse_journal_entry` with `reverses_entry_id` and dedicated idempotency key. Cleaner than ad‑hoc “storno” patterns.
+- **AR/AP open‑items subledger** — `ar_open_items`, `ap_open_items`, applications with aging fields.
+- **Automated GL posting from operational events** — sales, returns, goods receipts, payroll. Nothing has to be manually journalized to get a trial balance.
+- **All the main reports exist** — trial balance, GL, income statement, balance sheet — with optional `branch_id` filter.
+
+### 2.5 Identity, security, auditability
+
+- **Fixed base role catalog** (`SYSTEM_ROLE_SPECS`: Owner, IT Admin, HR Manager, Accountant, Cashier, Warehouse Manager, Marketing Manager, Floor Staff) with selector‑based permission seeding. Good separation‑of‑duties primitive that Manager.io does not have.
+- **Per‑user permission overrides (allow/deny)** merged on top of role permissions at the dependency layer.
+- **Session idle timeout** on refresh tokens; password reset tokens single‑use.
+- **Operational safety** — on startup failure MEZAN swallows the exception only to allow boot before Alembic (by design), but otherwise the bootstrap seeds permissions, roles, chart of accounts, and accounting settings.
+
+---
+
+## 3. Weaknesses and gaps (vs Odoo / Manager.io)
+
+These are grouped by area. Each item is something a customer coming from Odoo/Manager would expect and notice.
+
+### 3.1 Accounting depth
+
+| Capability | Odoo | Manager.io | MEZAN status |
+|---|---|---|---|
+| **Tax engine** (tax codes, inclusive/exclusive, tax on line) | Yes | Yes | **Missing.** Invoice scan parses `tax` but GL posts **revenue = total** with no tax liability split. VAT/sales‑tax reporting is impossible today. |
+| **Multi‑currency GL with FX revaluation** | Yes | Yes | Partial. `Currency`, `AccountingSettings.base_currency_id`, supplier currency exist; journal lines have **no currency column** and no FX amount. AR/AP open items carry `currency_code` but no revaluation routine. |
+| **Bank accounts & reconciliation** | Yes | Yes (core) | **Missing.** No bank statement import, no statement lines, no auto‑match. Cash is one default account. |
+| **Fixed assets / depreciation** | Yes | Yes | **Missing.** |
+| **Budgets** (budget vs actual) | Yes | Yes (basic) | **Missing.** |
+| **Cash flow statement** | Yes | Yes | **Missing** (confirmed in `PROJECT_STATE.md`). |
+| **Manual journal entries API/UI** | Yes | Yes | **Missing.** Only automated posting + reversal endpoint. An accountant cannot post an adjusting entry through the API. |
+| **Chart of accounts CRUD** | Yes | Yes | Seeded only. **No CRUD endpoints** for accounts (create sub‑accounts, rename, deactivate). |
+| **Analytic / dimensional accounting** beyond `branch_id` | Yes (analytic accounts / tags) | Limited (tracking codes) | **Missing.** No cost center, project, department, or custom dimension. |
+| **Tax reports / VAT return** | Yes | Yes | **Missing.** |
+| **Trial balance with opening + movement + closing columns** | Yes | Yes | MEZAN returns debit / credit / net only. |
+| **Report drill‑down & account‑level BS/P&L** | Yes | Yes | MEZAN BS/P&L aggregate by `account_type` enum (ASSET/LIABILITY/EQUITY/REVENUE/EXPENSE). No per‑account breakdown in those two reports. |
+| **Account types ‑ finer grouping** (current vs non‑current, equity vs retained earnings, etc.) | Yes | Yes | MEZAN’s enum has 5 values only; no sub‑classification. |
+| **Period close that transfers P&L to retained earnings** | Yes (year end close) | Yes | **Missing.** Year‑end close is not modeled; balance sheet just reads cumulative debits/credits. |
+| **Posting rule: only post to leaf (non‑control, non‑parent) accounts** | Yes | Yes | **Missing.** Any account can receive a line regardless of `is_control`. |
+
+### 3.2 POS sale → GL correctness gaps
+
+Looking at `document_posting_service.post_sales_invoice_gl`:
+
+- **Tender‑method blind.** Debit is always `default_cash_account_id`, regardless of whether the payment was cash or card. Manager.io and Odoo both route card settlements to a “card clearing” account that is cleared by the acquirer deposit. MEZAN will overstate till cash for every card sale.
+- **Account customer flow double‑posts cash.** For a customer sale, the service first accrues AR (Dr AR / Cr Revenue) and then immediately posts Dr Cash / Cr AR because the payment was already captured. That is effectively an invoice + receipt, but (a) it leaves no open AR in the subledger (AR open items are not auto‑created), and (b) it pretends every customer sale is paid in cash. There is no “credit sale on terms” path.
+- **No discount posting.** Cart discounts reduce `total`; there is no “sales discount” expense or contra‑revenue line in the GL, so management reporting loses the gross‑to‑net.
+- **No tax split.** As noted above.
+- **Return refund always hits cash.** `post_sales_return_gl` credits `default_cash_account_id`. Same tender‑method issue.
+
+### 3.3 Goods receipt → GL gaps
+
+- **No GR/IR (Goods Received / Invoice Received) clearing.** Goods receipt posts Dr Inventory / Cr AP directly. That assumes the supplier invoice has been accepted at receipt — which the invoice‑scan flow does imply, but there is no separate “vendor bill” concept, no 3‑way match, no posting to `GR/IR clearing` that is later cleared against the bill.
+- **AP open item is not auto‑created** on goods receipt. The AP subledger exists but is operated manually via `POST /accounting/ap/open-items`. The GL shows an AP balance that the subledger doesn’t know about. That is a **real reconciliation gap** — the subledger and GL can silently drift.
+- **No freight/landed cost allocation.** Odoo has landed costs; MEZAN only has unit_cost × qty.
+- **No PO→GR→Bill 3‑way match.** PO has no GL impact; it’s informational. In Odoo this is core.
+
+### 3.4 Inventory / costing gaps
+
+- **No FIFO/LIFO cost layers** (explicit in `PROJECT_STATE.md`).
+- **No stock valuation report by date** — you cannot ask “what was inventory on hand × unit cost on 2026‑03‑31?” from the API. The GL says what the **accounting** inventory was, but you can’t reconcile it against the physical ledger.
+- **No inventory adjustment → GL posting.** `inventory_adjustments` API changes stock but does not appear to post a write‑off / write‑up journal.
+- **No stock valuation variance** between GL inventory and WAVG × on‑hand.
+- **Transfers don’t hit GL.** For a single‑entity multi‑branch business with branch‑scoped P&L, an inter‑branch transfer **should** move the inventory asset from branch A to branch B in the GL (intra‑company transfer). Today the inventory line stays in the sending branch’s `branch_id` until the next sale/receipt.
+
+### 3.5 Reporting gaps
+
+- **Trial balance** — no opening balance column; no movement column.
+- **GL inquiry** — fine at the `(account_id, date_from, date_to)` level; no running balance column.
+- **Income statement / Balance sheet** — rolled up by `AccountType`. No account‑level lines. Not usable for real statutory output.
+- **No report export** (CSV / XLSX / PDF). Manager.io is essentially reports‑as‑a‑product.
+- **No comparative periods** (this year vs last year).
+- **No consolidation** (multi‑company roll‑up).
+- **No aging bucket report** for AR/AP, even though the subledger stores aging fields.
+
+### 3.6 Multi‑entity / multi‑currency
+
+- **No `company_id`/legal entity layer**. Branches are the only dimension. Odoo has `res.company` and Manager.io has one business per file. If MEZAN ever needs to sell two legal entities’ reports separately, that is a schema change.
+- **Single global chart of accounts.** Cannot support two legal entities with different CoAs.
+- **Journal lines are single‑currency**, denominated implicitly in base currency. Anything denominated in a foreign currency (supplier invoice in EUR) would need a currency + fx_rate + foreign_amount columns on `JournalEntryLine`.
+
+### 3.7 RBAC / data isolation
+
+- **Authorization is permission‑based, not branch‑scoped.** `deps.require_permission` checks that the user has `(resource, action)` but does not enforce “this user can only see branch 1 data.” `UserRole.branch_id` exists on the model but is not read by the dependency. In Odoo, record rules scope every query by `company_id`. In MEZAN, a cashier with the right permission can list/operate on any branch.
+- **No row‑level security (RLS)** in PostgreSQL. At the API layer only.
+- **Terminal API key is returned once** (good) but there is no terminal‑scoped JWT and no verification that a cart uses a terminal owned by the user’s branch.
+
+### 3.8 HR & payroll
+
+- **Hourly‑only model.** `payslip` computes hours × rate. No salaried employees, no allowances/bonuses, no employer taxes/social security contributions, no payroll tax tables per jurisdiction. Odoo Payroll has these (Enterprise); Manager.io has payslip templates with configurable earning/deduction items.
+- **Net payroll is posted to a single liability account.** No employee‑level sub‑ledger and no payment run that clears the liability when salaries are actually paid from the bank.
+- **No statutory reports** (social insurance, income tax withholding, end‑of‑service).
+
+### 3.9 Operational / DX gaps
+
+- **`main.py` lifespan swallows all exceptions** during startup seeding. Useful for first‑boot before migrations, but hides real failures in production. Should distinguish “no schema yet” from “seed failed.”
+- **Test harness only runs against PostgreSQL** and **only if `TEST_DATABASE_URL`/`DATABASE_URL_TEST` is set**, but CI sets `DATABASE_URL`. So the entire DB‑backed suite silently **session‑skips** on CI. Worth aligning.
+- **Tests hard‑code `branch_id: 1` / `2`** based on creation order in `admin_auth_header`. Fragile if anything seeds branches earlier.
+- **No OpenAPI schema versioning** (API is under `/api/v1` but there is no deprecation or compatibility policy).
+- **No background job queue.** Everything is in‑request. OCR in particular is a natural async job.
+- **No webhooks / outbox** for downstream integrations.
+
+---
+
+## 4. Risks / bugs surfaced by reading the code
+
+(Not a full audit, just what jumped out.)
+
+1. **`post_sales_invoice_gl`** credits cash for the customer‑credit path even though no cash changed hands in some scenarios. Over time this distorts the cash GL account vs the actual drawer.
+2. **`post_sales_return_gl`** always credits the default cash account. Card refunds are not modeled.
+3. **`inventory_adjustments`** API does not appear in `document_posting_service`. A positive adjustment increases physical stock but GL inventory stays the same → **GL vs physical drift**.
+4. **Goods receipt with a `Supplier` without `payables_account_id`** falls back to `default_ap_account_id`. Fine in aggregate, but the AP subledger is manual, so there is no per‑supplier AP from automation.
+5. **Seeder compares `AccountingSettings.id == 1`** — fine for a single‑tenant model, but fragile if the table is ever seeded from multiple deploys.
+6. **Lifespan `except Exception: pass`** — see §3.9.
+7. **`UserRole.branch_id`** is stored but never checked in `require_permission`, so scope is advertised but not enforced.
+
+---
+
+## 5. Recommended priorities
+
+Grouped by impact on the “honest ERP” story. No time estimates; each bullet is scoped by what it touches.
+
+### 5.1 Must‑fix correctness issues (retail+GL integrity)
+
+1. **Tender‑aware GL posting.** Extend `document_posting_service.post_sales_invoice_gl` and `post_sales_return_gl` to read the `PaymentReceipt.method` and post to a method‑specific account (`default_cash_account_id`, `default_card_clearing_account_id`, …). Requires a new field on `AccountingSettings`.
+2. **Auto‑create AR/AP open items from automated GL.** When a sales invoice posts to AR or a goods receipt posts to AP, also create the corresponding subledger row (`create_ar_open_item` / `create_ap_open_item`) with `source_type`/`source_id` linking back to the invoice/receipt. Then automated reconciliation of subledger vs GL becomes possible.
+3. **Stop the synthetic “cash” leg on customer sales.** If the customer truly paid at POS, the POS entry should be Dr Cash/Card‑clearing / Cr Revenue directly; AR should not be involved. If it’s on account, only accrue AR and leave the open item open. Two distinct finalize flows.
+4. **Post inventory adjustments to GL.** Write‑offs → Dr Expense (shrinkage) / Cr Inventory; write‑ups → Dr Inventory / Cr Other Income. Driven by a new `inventory_adjustment` source in `document_posting_service`.
+5. **GR/IR clearing and separate Vendor Bill.** Split receipt posting from bill posting: receipt → Dr Inventory / Cr GR/IR; bill → Dr GR/IR / Cr AP. Keeps physical receive separate from AP accrual.
+6. **Restrict posting to leaf, non‑control accounts** in `post_journal_entry`.
+7. **Close P&L to equity** at period close or at year end (`retained_earnings`), or compute the balance sheet with a `current_year_earnings` pseudo‑line. Today the balance sheet does not balance by construction for a year that has P&L.
+
+### 5.2 Table‑stakes accounting features
+
+8. **Tax engine.** Tax codes on products (and/or lines), inclusive/exclusive, tax → liability account in the journal. VAT return report.
+9. **Multi‑currency journal lines.** Add `currency_id`, `fx_rate`, `foreign_amount` columns to `journal_entry_lines`. FX revaluation routine for open AR/AP and FX‑denominated balances.
+10. **Manual journal entry API.** `POST /accounting/journal-entries` for accountants, with the same validations as automated posting (double‑entry, period open, leaf accounts).
+11. **Chart of accounts CRUD API.** Accountants need to add sub‑accounts without running migrations.
+12. **Better reports.** Trial balance: opening + movement + closing columns. P&L and BS: account‑level detail. CSV export. Aging buckets for AR/AP.
+13. **Cash flow statement** (indirect method is cheap given the existing GL).
+
+### 5.3 Operational & security
+
+14. **Branch‑scoped authorization.** `get_current_user_permissions` should return a map of `(resource, action) → allowed branch_ids`, and `require_permission` should also accept a `branch_id` argument read from the path/body. All queries should be filtered by the same.
+15. **Startup lifespan** should distinguish “no schema yet” from “seed failed” and log loudly in the second case.
+16. **Fix test env.** Make `conftest.py` fall back to `DATABASE_URL` when `TEST_DATABASE_URL` isn’t set, or update CI to export `TEST_DATABASE_URL`. Without this, the DB‑backed suite does not run in CI.
+17. **Background job queue** for OCR and for heavy backups.
+
+### 5.4 Nice‑to‑have (closes the distance to Odoo)
+
+- Analytic/dimensional accounting (`cost_center_id`, `project_id` on journal lines).
+- Fixed assets module.
+- Budgets.
+- Multi‑company / legal entity layer.
+- Bank statement import and reconciliation.
+- Landed costs.
+- Statutory reports per jurisdiction.
+
+---
+
+## 6. Where MEZAN wins vs each reference
+
+| vs **Odoo** | vs **Manager.io** |
+|---|---|
+| API‑first and async — cleaner integration surface | Has POS, HR, inventory (Manager.io has none) |
+| Branch‑scoped GL lines by default | Audit log with `request_id` on every mutation |
+| Idempotency everywhere (journals, stock, payments) | Fixed‑role catalog with per‑user overrides |
+| OCR invoice pipeline is first‑class (not Enterprise add‑on) | Multi‑branch stock and transfers |
+| Cleaner cart/shift/finalize state machines | Weighted‑average cost per branch |
+
+## 7. Where MEZAN loses vs each reference
+
+| vs **Odoo** | vs **Manager.io** |
+|---|---|
+| No tax engine, no analytic accounts, no multi‑company | No bank reconciliation, no VAT return, no fixed assets |
+| No manual journals, no CoA CRUD, no year‑end close | Reports are type‑rollups only, no account detail, no CSV/PDF export |
+| No landed costs, no PO→GR→Bill 3‑way match | No manual journals API |
+| POS → GL ignores tender method and tax | No statutory tax reports |
+| No branch‑scoped row‑level authorization | No aging bucket report despite having the data |
+
+---
+
+## 8. What the Happy User Journey test proves
+
+See `tests/test_happy_journey.py`. It walks the full path:
+
+1. Branch creation (warehouse + storefront).
+2. A staff user is created and assigned the **Admin** role (the journey also exercises role assignment).
+3. Category + dynamic attributes + product + barcode.
+4. Supplier master + purchase order.
+5. Invoice scan → manual override → validate → **goods receipt + GL posting (Dr Inventory / Cr AP)**.
+6. Inter‑branch transfer (warehouse → store) with dispatch + receive.
+7. POS terminal creation + authorization.
+8. Shift open at the storefront terminal.
+9. Cart create → add line → finalize discount → park/resume/lock.
+10. Payment intent + capture (card, mock provider).
+11. Sales invoice finalize → immutable invoice, stock out, **GL posting (Dr Cash / Cr Revenue, Dr COGS / Cr Inventory)**.
+12. Shift close with declared cash.
+13. Assertions on **`/accounting/trial-balance`**: Inventory, AP, Cash, Revenue, COGS all carry the expected signs; debits equal credits.
+14. Assertions on **`/accounting/income-statement`** and **`/accounting/balance-sheet`** for the same date window.
+
+This is the end‑to‑end “retail → books” loop that MEZAN claims to deliver, run as one test.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,25 +67,40 @@ async def client(db_session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
 
 @pytest.fixture()
 async def admin_auth_header(db_session: AsyncSession) -> dict[str, str]:
-    # Ensure permissions + Admin role exist
+    # Ensure permissions + Admin role exist (idempotent).
     await seed_permissions_and_roles(db_session)
     await seed_accounting_defaults(db_session)
 
-    # Create a branch for inventory tests
-    wh = Branch(name="Main Warehouse", code="WH1", address=None, timezone="UTC", is_active=True)
-    store = Branch(name="Store A", code="ST1", address=None, timezone="UTC", is_active=True)
-    db_session.add_all([wh, store])
+    # Ensure canonical warehouse/store branches exist. Because the DB schema is
+    # shared across the pytest session, re-use existing rows if a previous test
+    # already created them (keeps branch IDs stable at 1/2 and avoids unique
+    # constraint failures when multiple tests call this fixture).
+    existing_wh = await db_session.execute(select(Branch).where(Branch.code == "WH1"))
+    if existing_wh.scalar_one_or_none() is None:
+        db_session.add(
+            Branch(name="Main Warehouse", code="WH1", address=None, timezone="UTC", is_active=True)
+        )
+    existing_store = await db_session.execute(select(Branch).where(Branch.code == "ST1"))
+    if existing_store.scalar_one_or_none() is None:
+        db_session.add(
+            Branch(name="Store A", code="ST1", address=None, timezone="UTC", is_active=True)
+        )
     await db_session.flush()
 
-    user = User(
-        email="admin@example.com",
-        full_name="Admin",
-        password_hash=hash_password("password123"),
-        status="active",
-        branch_id=None,
-    )
-    db_session.add(user)
-    await db_session.flush()
+    # Reuse the admin user across tests so that the Bearer token is always valid
+    # and unique constraints on email are not violated.
+    user_result = await db_session.execute(select(User).where(User.email == "admin@example.com"))
+    user = user_result.scalar_one_or_none()
+    if user is None:
+        user = User(
+            email="admin@example.com",
+            full_name="Admin",
+            password_hash=hash_password("password123"),
+            status="active",
+            branch_id=None,
+        )
+        db_session.add(user)
+        await db_session.flush()
 
     role_result = await db_session.execute(select(Role).where(Role.name == ADMIN_ROLE_NAME))
     role = role_result.scalar_one_or_none()
@@ -95,7 +110,11 @@ async def admin_auth_header(db_session: AsyncSession) -> dict[str, str]:
         db_session.add(role)
         await db_session.flush()
 
-    db_session.add(UserRole(user_id=user.id, role_id=role.id, branch_id=None))
+    has_role = await db_session.execute(
+        select(UserRole).where(UserRole.user_id == user.id, UserRole.role_id == role.id)
+    )
+    if has_role.scalar_one_or_none() is None:
+        db_session.add(UserRole(user_id=user.id, role_id=role.id, branch_id=None))
     await db_session.commit()
 
     token = create_access_token(user.id)

--- a/tests/test_happy_journey.py
+++ b/tests/test_happy_journey.py
@@ -1,0 +1,568 @@
+"""Happy User Journey: branch + user creation → purchasing → POS sale → trial balance.
+
+This is an end-to-end integration test that exercises the full "retail → books"
+loop. It deliberately uses HTTP endpoints (not services) so it reflects what a
+real front-end client of MEZAN would see.
+
+Requires `TEST_DATABASE_URL` (or `DATABASE_URL_TEST`) to be set, otherwise the
+session is skipped (same convention as the rest of the suite).
+
+Flow:
+    1.  Bootstrap (via fixture): permissions, roles, Admin user, system branches.
+    2.  IT Admin creates a fresh warehouse + storefront branch through the API.
+    3.  IT Admin creates a cashier user and grants them the CASHIER role.
+    4.  Warehouse Manager (admin token) sets up supplier + category + product
+        with a price attribute and a standard cost.
+    5.  A PO is drafted and sent.
+    6.  An invoice scan is created, manually overridden and validated →
+        goods receipt is posted → Dr Inventory / Cr AP hits the GL.
+    7.  Stock is transferred warehouse → storefront (dispatch + receive).
+    8.  A POS terminal is registered + authorized at the storefront.
+    9.  A shift is opened at that terminal.
+    10. A walk-in cart is created → product added → discount applied →
+        park / resume / lock.
+    11. Payment intent is created and captured (mock provider, card).
+    12. Sale is finalized → immutable invoice, stock out, and GL posting
+        (Dr Cash / Cr Revenue, Dr COGS / Cr Inventory).
+    13. Shift is closed with declared cash.
+    14. Trial balance is fetched and asserted: debits == credits,
+        Inventory / AP / Cash / Revenue / COGS carry the expected signs and the
+        net P&L lines up with the income statement.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chart_accounts import ChartAccount
+from app.models.currency import Currency
+
+
+async def _lookup_account_ids_by_code(db: AsyncSession) -> dict[str, int]:
+    res = await db.execute(select(ChartAccount))
+    return {a.code: a.id for a in res.scalars().all()}
+
+
+async def _get_usd_currency_id(db: AsyncSession) -> int:
+    res = await db.execute(select(Currency).where(Currency.code == "USD"))
+    row = res.scalar_one_or_none()
+    assert row is not None, "USD currency should be seeded by seed_accounting_defaults"
+    return row.id
+
+
+@pytest.mark.asyncio
+async def test_happy_user_journey_from_branch_entry_to_trial_balance(
+    client, admin_auth_header, db_session: AsyncSession
+):
+    hdr = admin_auth_header
+    today = date.today()
+    suffix = uuid.uuid4().hex[:6]
+
+    # -----------------------------------------------------------------
+    # 1. Bootstrap: chart of accounts + default currency already seeded
+    # by admin_auth_header. Look up the account IDs we'll assert against.
+    # -----------------------------------------------------------------
+    accounts = await _lookup_account_ids_by_code(db_session)
+    assert {"1000", "1100", "1200", "2000", "4000", "5000"}.issubset(accounts.keys()), (
+        "Seeded chart of accounts is missing expected codes"
+    )
+    usd_id = await _get_usd_currency_id(db_session)
+
+    # -----------------------------------------------------------------
+    # 2. IT Admin creates a fresh warehouse + storefront branch
+    # (separate from the fixture-created WH1/ST1 to exercise the real
+    # branch API and get stable IDs the journey will own).
+    # -----------------------------------------------------------------
+    wh_resp = await client.post(
+        "/api/v1/branches",
+        headers=hdr,
+        json={
+            "name": f"HQ Warehouse {suffix}",
+            "code": f"HQWH-{suffix}",
+            "address": "10 Depot Rd",
+            "timezone": "UTC",
+        },
+    )
+    assert wh_resp.status_code == 200, wh_resp.text
+    warehouse_id = wh_resp.json()["id"]
+
+    store_resp = await client.post(
+        "/api/v1/branches",
+        headers=hdr,
+        json={
+            "name": f"Downtown Store {suffix}",
+            "code": f"DTST-{suffix}",
+            "address": "55 Main St",
+            "timezone": "UTC",
+        },
+    )
+    assert store_resp.status_code == 200, store_resp.text
+    store_id = store_resp.json()["id"]
+    assert store_id != warehouse_id
+
+    # -----------------------------------------------------------------
+    # 3. IT Admin creates a cashier user and grants them the CASHIER role.
+    # The journey still runs API calls with the admin token (RBAC-wise
+    # any role would work for the same endpoints), but this verifies the
+    # user-lifecycle + role-assignment path is functional.
+    # -----------------------------------------------------------------
+    cashier_email = f"cashier+{suffix}@example.com"
+    user_resp = await client.post(
+        "/api/v1/users",
+        headers=hdr,
+        json={
+            "email": cashier_email,
+            "full_name": "Happy Cashier",
+            "password": "Passw0rd!cashier",
+            "status": "active",
+            "branch_id": store_id,
+            "role_code": "CASHIER",
+            "require_onboarding": False,
+        },
+    )
+    assert user_resp.status_code == 200, user_resp.text
+    cashier = user_resp.json()
+    assert cashier["email"] == cashier_email
+    assert cashier["branch_id"] == store_id
+
+    roles_resp = await client.get(
+        f"/api/v1/users/{cashier['id']}/roles", headers=hdr
+    )
+    assert roles_resp.status_code == 200, roles_resp.text
+    assert any(r["role_code"] == "CASHIER" for r in roles_resp.json())
+
+    # -----------------------------------------------------------------
+    # 4. Supplier + category + attribute + product.
+    # -----------------------------------------------------------------
+    supplier_resp = await client.post(
+        "/api/v1/suppliers",
+        headers=hdr,
+        json={
+            "code": f"SUP-{suffix}",
+            "name": "Acme Wholesale",
+            "currency_id": usd_id,
+            "payables_account_id": accounts["2000"],
+        },
+    )
+    assert supplier_resp.status_code == 200, supplier_resp.text
+    supplier_id = supplier_resp.json()["id"]
+
+    cat_resp = await client.post(
+        "/api/v1/categories",
+        headers=hdr,
+        json={
+            "name": f"Gadgets-{suffix}",
+            "slug": f"gadgets-{suffix}",
+            "sort_order": 0,
+            "is_active": True,
+        },
+    )
+    assert cat_resp.status_code == 201, cat_resp.text
+    category_id = cat_resp.json()["id"]
+
+    price_attr = await client.post(
+        f"/api/v1/categories/{category_id}/attributes",
+        headers=hdr,
+        json={
+            "key": "price",
+            "label": "Price",
+            "type": "float",
+            "required": True,
+            "sort_order": 0,
+        },
+    )
+    assert price_attr.status_code == 201, price_attr.text
+
+    product_resp = await client.post(
+        "/api/v1/products",
+        headers=hdr,
+        json={
+            "category_id": category_id,
+            "name": "Widget Pro",
+            "sku": f"WGT-{suffix}",
+            "status": "active",
+            "standard_cost": 6.0,
+            "attributes": {"price": 10.0},
+        },
+    )
+    assert product_resp.status_code == 201, product_resp.text
+    product_id = product_resp.json()["id"]
+
+    barcode_resp = await client.post(
+        f"/api/v1/products/{product_id}/barcode", headers=hdr
+    )
+    assert barcode_resp.status_code == 200, barcode_resp.text
+    assert barcode_resp.json()["barcode"]
+
+    # -----------------------------------------------------------------
+    # 5. Purchase order draft + send.
+    # -----------------------------------------------------------------
+    po_qty = 10
+    po_unit_cost = 6.0
+    po_resp = await client.post(
+        "/api/v1/purchase-orders",
+        headers=hdr,
+        json={
+            "supplier_name": "Acme Wholesale",
+            "supplier_id": supplier_id,
+            "notes": "Initial fill",
+            "lines": [
+                {"product_id": product_id, "qty": po_qty, "unit_cost": po_unit_cost}
+            ],
+        },
+    )
+    # supplier_id is optional in the purchase order schema in some repos.
+    if po_resp.status_code != 201:
+        po_resp = await client.post(
+            "/api/v1/purchase-orders",
+            headers=hdr,
+            json={
+                "supplier_name": "Acme Wholesale",
+                "notes": "Initial fill",
+                "lines": [
+                    {
+                        "product_id": product_id,
+                        "qty": po_qty,
+                        "unit_cost": po_unit_cost,
+                    }
+                ],
+            },
+        )
+    assert po_resp.status_code == 201, po_resp.text
+    po_id = po_resp.json()["id"]
+    send_resp = await client.post(
+        f"/api/v1/purchase-orders/{po_id}/send", headers=hdr
+    )
+    assert send_resp.status_code == 200, send_resp.text
+
+    # -----------------------------------------------------------------
+    # 6. Invoice scan → manual override → validate → goods receipt + GL post.
+    # GL expected: Dr Inventory (1200) / Cr AP (2000) for qty * unit_cost.
+    # -----------------------------------------------------------------
+    scan_resp = await client.post(
+        "/api/v1/invoice-scans",
+        headers=hdr,
+        json={"source_type": "qr", "data": f"JOURNEY-{suffix}"},
+    )
+    assert scan_resp.status_code == 201, scan_resp.text
+    scan_id = scan_resp.json()["id"]
+
+    override_resp = await client.patch(
+        f"/api/v1/invoice-scans/{scan_id}/override",
+        headers=hdr,
+        json={
+            "override_output": {
+                "supplier_name": "Acme Wholesale",
+                "invoice_number": f"ACME-INV-{suffix}",
+                "line_items": [
+                    {
+                        "product_id": product_id,
+                        "qty": po_qty,
+                        "unit_cost": po_unit_cost,
+                    }
+                ],
+            }
+        },
+    )
+    assert override_resp.status_code == 200, override_resp.text
+
+    validate_resp = await client.post(
+        f"/api/v1/invoice-scans/{scan_id}/validate",
+        headers=hdr,
+        json={"branch_id": warehouse_id},
+    )
+    assert validate_resp.status_code == 200, validate_resp.text
+    assert validate_resp.json()["scan"]["status"] == "validated"
+    assert validate_resp.json()["goods_receipt_id"]
+
+    expected_inventory_dr = po_qty * po_unit_cost  # 60.00
+
+    # -----------------------------------------------------------------
+    # 7. Transfer some stock to the storefront (dispatch + receive).
+    # Transfers do not hit the GL today, only stock movements.
+    # -----------------------------------------------------------------
+    transfer_qty = 4
+    xfer_resp = await client.post(
+        "/api/v1/transfers",
+        headers=hdr,
+        json={
+            "from_branch_id": warehouse_id,
+            "to_branch_id": store_id,
+            "lines": [{"product_id": product_id, "qty": transfer_qty}],
+        },
+    )
+    assert xfer_resp.status_code == 201, xfer_resp.text
+    batch_id = xfer_resp.json()["id"]
+
+    dispatched = await client.post(
+        f"/api/v1/transfers/{batch_id}/dispatch", headers=hdr
+    )
+    assert dispatched.status_code == 200, dispatched.text
+    assert dispatched.json()["status"] == "in_transit"
+
+    received = await client.post(
+        f"/api/v1/transfers/{batch_id}/receive", headers=hdr
+    )
+    assert received.status_code == 200, received.text
+    assert received.json()["status"] == "received"
+
+    # -----------------------------------------------------------------
+    # 8. POS terminal registration + authorization at the storefront.
+    # -----------------------------------------------------------------
+    term_resp = await client.post(
+        "/api/v1/terminals",
+        headers=hdr,
+        json={
+            "branch_id": store_id,
+            "name": f"POS-{suffix}",
+            "terminal_code": f"POS-{suffix}",
+        },
+    )
+    assert term_resp.status_code == 200, term_resp.text
+    terminal_id = term_resp.json()["id"]
+    auth_resp = await client.patch(
+        f"/api/v1/terminals/{terminal_id}/authorize", headers=hdr
+    )
+    assert auth_resp.status_code == 200, auth_resp.text
+    assert auth_resp.json()["is_authorized"] is True
+
+    # -----------------------------------------------------------------
+    # 9. Shift open.
+    # -----------------------------------------------------------------
+    shift_resp = await client.post(
+        "/api/v1/pos/shifts/open",
+        headers=hdr,
+        json={"terminal_id": terminal_id, "opening_float": 100.0},
+    )
+    assert shift_resp.status_code == 201, shift_resp.text
+    shift_id = shift_resp.json()["id"]
+
+    # -----------------------------------------------------------------
+    # 10. Cart create → add line → apply discount → park / resume / lock.
+    # -----------------------------------------------------------------
+    cart_resp = await client.post(
+        "/api/v1/pos/carts",
+        headers=hdr,
+        json={"terminal_id": terminal_id, "shift_id": shift_id, "customer_id": None},
+    )
+    assert cart_resp.status_code == 201, cart_resp.text
+    cart_id = cart_resp.json()["id"]
+    assert cart_resp.json()["branch_id"] == store_id
+
+    sell_qty = 2
+    unit_price = 10.0
+    line_resp = await client.post(
+        f"/api/v1/pos/carts/{cart_id}/lines",
+        headers=hdr,
+        json={"product_id": product_id, "qty": sell_qty},
+    )
+    assert line_resp.status_code == 200, line_resp.text
+    assert line_resp.json()["subtotal"] == pytest.approx(sell_qty * unit_price)
+
+    disc_amount = 5.0
+    disc_resp = await client.post(
+        f"/api/v1/pos/carts/{cart_id}/discounts",
+        headers=hdr,
+        json={"code": "WELCOME", "amount": disc_amount},
+    )
+    assert disc_resp.status_code == 200, disc_resp.text
+    cart_total = sell_qty * unit_price - disc_amount  # 15.00
+    assert disc_resp.json()["total"] == pytest.approx(cart_total)
+
+    for action in ("park", "resume", "lock"):
+        r = await client.post(
+            f"/api/v1/pos/carts/{cart_id}/state",
+            headers=hdr,
+            json={"action": action},
+        )
+        assert r.status_code == 200, r.text
+
+    # -----------------------------------------------------------------
+    # 11. Payment intent + capture (mock provider, card).
+    # -----------------------------------------------------------------
+    intent_resp = await client.post(
+        "/api/v1/pos/payments/intents",
+        headers=hdr,
+        json={"cart_id": cart_id, "provider": "mock", "currency": "USD"},
+    )
+    assert intent_resp.status_code == 201, intent_resp.text
+    intent_id = intent_resp.json()["id"]
+    assert intent_resp.json()["amount"] == pytest.approx(cart_total)
+
+    capture_idem = f"cap-journey-{suffix}"
+    capture_resp = await client.post(
+        "/api/v1/pos/payments/capture",
+        headers=hdr,
+        json={
+            "payment_intent_id": intent_id,
+            "idempotency_key": capture_idem,
+            "method": "card",
+            "reference": "journey-card-1",
+            "card_last4": "4242",
+        },
+    )
+    assert capture_resp.status_code == 200, capture_resp.text
+    assert capture_resp.json()["status"] == "succeeded"
+
+    # -----------------------------------------------------------------
+    # 12. Finalize sale → immutable invoice + stock out + GL post.
+    # For a walk-in (customer_id None) the service posts one batch:
+    #   Dr Cash / Cr Revenue for total, and if COGS > 0 also Dr COGS / Cr Inventory.
+    # COGS is WAVG × qty, and since the goods receipt was the first receipt,
+    # WAVG == po_unit_cost.
+    # -----------------------------------------------------------------
+    finalize_resp = await client.post(
+        "/api/v1/pos/sales/finalize",
+        headers=hdr,
+        json={
+            "cart_id": cart_id,
+            "payment_intent_id": intent_id,
+            "idempotency_key": f"final-journey-{suffix}",
+        },
+    )
+    assert finalize_resp.status_code == 200, finalize_resp.text
+    invoice = finalize_resp.json()
+    assert invoice["total"] == pytest.approx(cart_total)
+    assert invoice["branch_id"] == store_id
+
+    expected_cogs = sell_qty * po_unit_cost  # 12.00
+    expected_revenue = cart_total  # 15.00
+
+    # -----------------------------------------------------------------
+    # 13. Shift close.
+    # -----------------------------------------------------------------
+    close_resp = await client.post(
+        f"/api/v1/pos/shifts/{shift_id}/close",
+        headers=hdr,
+        json={"declared_cash": 100.0},
+    )
+    assert close_resp.status_code == 200, close_resp.text
+
+    # -----------------------------------------------------------------
+    # 14. Trial balance assertions. Because other tests may have posted
+    # journal entries against the same global chart of accounts, we
+    # isolate by filtering the trial balance to the two branches we
+    # created in this journey. Every automated posting we produced here
+    # is tagged with one of those branch ids.
+    # -----------------------------------------------------------------
+    as_of = (today + timedelta(days=1)).isoformat()
+
+    async def _tb_for(branch_id: int) -> dict[str, dict]:
+        resp = await client.get(
+            "/api/v1/accounting/trial-balance",
+            headers=hdr,
+            params={"as_of": as_of, "branch_id": branch_id},
+        )
+        assert resp.status_code == 200, resp.text
+        return {row["code"]: row for row in resp.json()}
+
+    tb_wh = await _tb_for(warehouse_id)
+    tb_store = await _tb_for(store_id)
+
+    def _balanced(by_code: dict[str, dict]) -> None:
+        total_dr = round(sum(row["total_debit"] for row in by_code.values()), 2)
+        total_cr = round(sum(row["total_credit"] for row in by_code.values()), 2)
+        assert total_dr == total_cr, (
+            f"Branch trial balance unbalanced: debits={total_dr}, credits={total_cr}"
+        )
+
+    _balanced(tb_wh)
+    _balanced(tb_store)
+
+    # Warehouse branch: one goods receipt → Dr Inventory / Cr AP at 60.00.
+    assert tb_wh["1200"]["net"] == pytest.approx(expected_inventory_dr), tb_wh["1200"]
+    assert tb_wh["2000"]["net"] == pytest.approx(-expected_inventory_dr), tb_wh["2000"]
+
+    # Storefront branch:
+    #   one walk-in sale posts Dr Cash 15 / Cr Revenue 15 and
+    #   Dr COGS 12 / Cr Inventory 12 (the WAVG draw-down at sale time).
+    assert tb_store["1000"]["net"] == pytest.approx(expected_revenue), tb_store["1000"]
+    assert tb_store["4000"]["net"] == pytest.approx(-expected_revenue), tb_store["4000"]
+    assert tb_store["5000"]["net"] == pytest.approx(expected_cogs), tb_store["5000"]
+    assert tb_store["1200"]["net"] == pytest.approx(-expected_cogs), tb_store["1200"]
+
+    # Global trial balance must still balance for the whole org.
+    tb_global_resp = await client.get(
+        "/api/v1/accounting/trial-balance",
+        headers=hdr,
+        params={"as_of": as_of},
+    )
+    assert tb_global_resp.status_code == 200, tb_global_resp.text
+    tb_global = tb_global_resp.json()
+    assert tb_global, "Global trial balance should not be empty"
+    total_dr = round(sum(row["total_debit"] for row in tb_global), 2)
+    total_cr = round(sum(row["total_credit"] for row in tb_global), 2)
+    assert total_dr == total_cr, (
+        f"Global trial balance unbalanced: debits={total_dr}, credits={total_cr}"
+    )
+
+    # -----------------------------------------------------------------
+    # Cross-check with the storefront income statement for the period.
+    # -----------------------------------------------------------------
+    period_start = (today - timedelta(days=1)).isoformat()
+    period_end = (today + timedelta(days=1)).isoformat()
+    is_resp = await client.get(
+        "/api/v1/accounting/income-statement",
+        headers=hdr,
+        params={
+            "period_start": period_start,
+            "period_end": period_end,
+            "branch_id": store_id,
+        },
+    )
+    assert is_resp.status_code == 200, is_resp.text
+    is_data = is_resp.json()
+    assert is_data["total_revenue"] == pytest.approx(expected_revenue)
+    assert is_data["total_expense"] == pytest.approx(expected_cogs)
+    assert is_data["net_income"] == pytest.approx(expected_revenue - expected_cogs)
+
+    # -----------------------------------------------------------------
+    # Balance-sheet identity per branch. Because MEZAN does not auto-close
+    # P&L into retained earnings, the gap
+    #   total_assets - total_liabilities - total_equity
+    # equals the unclosed net income / (-net expense) for that branch.
+    # For the warehouse: Dr Inv 60 / Cr AP 60 → identity 0.
+    # For the storefront: Dr Cash 15 / Dr COGS 12 / Cr Rev 15 / Cr Inv 12
+    #                    → net income 3 → identity 3.
+    # -----------------------------------------------------------------
+    bs_wh = await client.get(
+        "/api/v1/accounting/balance-sheet",
+        headers=hdr,
+        params={"as_of": as_of, "branch_id": warehouse_id},
+    )
+    assert bs_wh.status_code == 200, bs_wh.text
+    assert bs_wh.json()["assets_minus_liabilities_equity"] == pytest.approx(0.0)
+
+    bs_store = await client.get(
+        "/api/v1/accounting/balance-sheet",
+        headers=hdr,
+        params={"as_of": as_of, "branch_id": store_id},
+    )
+    assert bs_store.status_code == 200, bs_store.text
+    assert bs_store.json()["assets_minus_liabilities_equity"] == pytest.approx(
+        expected_revenue - expected_cogs
+    )
+
+    # -----------------------------------------------------------------
+    # Fetch GL for Revenue (storefront) and assert the source is the
+    # sales invoice we just created.
+    # -----------------------------------------------------------------
+    gl_resp = await client.get(
+        "/api/v1/accounting/general-ledger",
+        headers=hdr,
+        params={
+            "account_id": accounts["4000"],
+            "date_from": period_start,
+            "date_to": period_end,
+            "branch_id": store_id,
+        },
+    )
+    assert gl_resp.status_code == 200, gl_resp.text
+    gl_lines = gl_resp.json()
+    assert any(ln["source_type"] == "sales_invoice" for ln in gl_lines), gl_lines
+    assert sum(ln["credit"] for ln in gl_lines) == pytest.approx(expected_revenue)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two deliverables requested from the review of the MEZAN backend + database:

1. **`docs/ANALYSIS.md`** — structured comparison of the current backend against **Odoo** and **Manager.io**, with strengths, weaknesses, risks/bugs surfaced by reading the code, and a prioritised follow-up list.
2. **`tests/test_happy_journey.py`** — a single pytest that walks the *full* retail-to-books loop through the public HTTP API, from branch and user creation all the way to the trial balance.

A small conftest fix is included so the shared session-scoped DB no longer causes unique-constraint collisions when more than one test uses `admin_auth_header`.

## `docs/ANALYSIS.md` highlights

**Strengths** — clean `api/services/models/schemas` layering, fully async SQLAlchemy, idempotency on journals/stock/payments, Alembic-only migrations, audit log with `request_id`, enforced double-entry at cents, mandatory `branch_id` on every journal line, fiscal period lock, journal reversal workflow, automated GL posting from sales/returns/goods receipts/payroll, fixed base-role catalog with per-user overrides, per-branch weighted-average inventory costing, OCR invoice pipeline as a first-class citizen.

**Weaknesses vs Odoo/Manager.io** —

- No tax engine; POS posts revenue = total with no tax split.
- No bank reconciliation, fixed assets, budgets, or cash-flow statement.
- No manual journal API, no chart-of-accounts CRUD, no year-end close that transfers P&L to retained earnings, no restriction of postings to leaf/non-control accounts.
- P&L and balance-sheet reports roll up by `AccountType` enum only — no account-level detail, no export.
- Multi-currency: base currency exists but `JournalEntryLine` has no `currency_id`/`fx_rate`/`foreign_amount`; no FX revaluation.
- No analytic/dimensional accounting beyond `branch_id`, no multi-company/legal-entity layer.
- RBAC is global per permission; `UserRole.branch_id` is stored but not enforced in `require_permission`.

**Risks/bugs surfaced from the code** —

- `post_sales_invoice_gl` always debits the default cash account, regardless of payment tender (card sales overstate till cash).
- For customer sales the service posts AR then immediately clears it to cash — no credit sale on terms, AR open items are not auto-created.
- `post_sales_return_gl` always credits cash — card refunds are not modeled.
- Goods receipt posts directly to AP without a GR/IR clearing step and does not auto-create an AP open item, so the subledger can drift from the GL.
- Inventory adjustments change stock but do not post to GL, so physical stock and GL inventory can drift.
- `main.py` lifespan swallows all startup exceptions, hiding real seed failures in production.
- Test harness only runs on `TEST_DATABASE_URL`/`DATABASE_URL_TEST`, but CI sets `DATABASE_URL`, so the DB-backed suite silently skips.

**Prioritised follow-ups** — tender-aware GL posting, auto-create AR/AP open items from automated GL, separate the credit-sale flow from the cash-sale flow, post inventory adjustments to GL, GR/IR clearing, leaf-only posting, period/year close, then tax engine, multi-currency journals, manual journal API, chart-of-accounts CRUD, better reports with CSV export and aging buckets, cash-flow statement, branch-scoped authorization.

## `tests/test_happy_journey.py`

A single pytest, 14 steps, all against `/api/v1/*`:

1. Create warehouse + storefront branches.
2. Create a cashier user and assign the `CASHIER` role.
3. Supplier + category + category attribute + product (with `standard_cost`) + barcode.
4. Draft and send a purchase order.
5. Invoice scan → manual override → validate → goods receipt + `Dr Inventory / Cr AP`.
6. Warehouse → store transfer (dispatch + receive).
7. Register and authorise a POS terminal at the storefront.
8. Open a shift.
9. Walk-in cart: add line, apply discount, park/resume/lock.
10. Payment intent + capture (mock provider, card).
11. Finalize sale → immutable invoice, stock-out, `Dr Cash / Cr Revenue` + `Dr COGS / Cr Inventory`.
12. Close shift with declared cash.
13. Pull per-branch trial balances and assert each key account (`1000` Cash, `1200` Inventory, `2000` AP, `4000` Revenue, `5000` COGS) carries the expected sign and amount. Also assert debits equal credits per branch and globally, that the storefront income statement matches, and that the balance-sheet identity gap per branch equals the unclosed net income for that branch.
14. Read the revenue general-ledger back and assert the source row points at the sales invoice.

The test uses fresh unique branches per run (no hard-coded `branch_id: 1/2`) so it can run alongside the existing integration tests without cross-contamination.

## Running the journey test

```bash
# requires a running Postgres
export TEST_DATABASE_URL="postgresql+asyncpg://user:pass@localhost/mezan_test"
uv run pytest tests/test_happy_journey.py -v
```

(Without `TEST_DATABASE_URL`/`DATABASE_URL_TEST` the test session-skips — same behaviour as the rest of the DB-backed suite.)

## Files

- `docs/ANALYSIS.md` — new.
- `tests/test_happy_journey.py` — new.
- `tests/conftest.py` — make `admin_auth_header` idempotent (get-or-create for branches/user/role assignment).
- `PROJECT_STATE.md` — cross-link to the new analysis doc and journey test.

## Verification performed

- `uv run pytest tests/ --collect-only` — all 9 tests (existing + new) collect cleanly.
- `uv run ruff check` — clean on the new files.
- Actual run against a live Postgres was not performed here (no DB in the agent environment); the test assertions are written against the exact posting patterns in `document_posting_service.py` and the settings seeded by `seed_accounting_defaults`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef88202f-de2e-4708-8e2b-ad01d32586be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef88202f-de2e-4708-8e2b-ad01d32586be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

